### PR TITLE
Merge Epic E0: Testing & Tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
   "workspaceFolder": "/workspaces/stack-root",
 
   "mounts": [
+    "source=${localEnv:HOME}/.gitmessage.txt,target=/home/app-user/.gitmessage.txt,type=bind,consistency=cached",
     "source=${localWorkspaceFolder},target=/workspaces/stack-root,type=bind,consistency=cached",
     "source=vscode-server,target=/home/app-user/.vscode-server,type=volume",
     "source=composer-cache,target=/home/app-user/.composer/cache,type=volume",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: CI
+
 on:
   pull_request:
   push:
-    branches: [main, "epic/**", "feature/**"]
+    branches: [main, "epic/**", "feature/**", "chore/**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pint:
@@ -10,17 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
           tools: composer
-
-      - name: Composer install (backend app)
+      - name: Composer install (app)
         working-directory: apps/backend
         run: composer install --no-interaction --prefer-dist
-
+      # run from backend so vendor/bin/pint exists
       - name: Pint (app + package)
+        working-directory: apps/backend
         run: vendor/bin/pint --test . ../../packages/plenipotentiary-laravel
 
   pest:
@@ -28,22 +33,69 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
           tools: composer
-
-      - name: Composer install (backend app)
+          extensions: sqlite, sqlite3, pdo_sqlite
+      - name: Composer install (app)
         working-directory: apps/backend
         run: composer install --no-interaction --prefer-dist
-
+      # minimal test env so view cache & app key exist
+      - name: Prepare test env
+        working-directory: apps/backend
+        shell: bash
+        run: |
+          set -eu
+          rm -f .env
+          cat > .env <<'ENV'
+          APP_ENV=testing
+          APP_DEBUG=true
+          CACHE_STORE=array
+          CACHE_DRIVER=array
+          SESSION_DRIVER=array
+          QUEUE_CONNECTION=sync
+          BROADCAST_DRIVER=log
+          MAIL_MAILER=array
+          DB_CONNECTION=sqlite
+          DB_DATABASE=:memory:
+          ENV
+          echo "APP_KEY=$(php -r "echo 'base64:'.base64_encode(random_bytes(32));")" >> .env
+          echo "VIEW_COMPILED_PATH=$(pwd)/storage/framework/views" >> .env
+          mkdir -p storage/framework/{cache,views} bootstrap/cache
+          php artisan config:clear
+          php artisan route:clear
       - name: Pest (backend app)
         working-directory: apps/backend
         run: vendor/bin/pest --colors=always --testsuite=Feature
-
       - name: Pest (package plenipotentiary-laravel)
         working-directory: packages/plenipotentiary-laravel
+        env:
+          EXAMPLES_ROOT: ${{ github.workspace }}/docs/openapi/examples
         run: |
           composer install --no-interaction --prefer-dist
-          vendor/bin/pest --colors=always
+          vendor/bin/pest --colors=always --testsuite=Contracts
+          vendor/bin/pest --colors=always --testsuite=Package
+          vendor/bin/pest --colors=always --testsuite=Feature
+          vendor/bin/pest --colors=always --testsuite=Unit
+
+  phpstan:
+    name: PHPStan (app + package)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+      - name: Install composer deps (app)
+        working-directory: apps/backend
+        run: composer install --no-interaction --prefer-dist
+      - name: Cache PHPStan results
+        uses: actions/cache@v4
+        with:
+          path: apps/backend/.phpstan
+          key: phpstan-${{ hashFiles('apps/backend/phpstan.neon.dist','apps/backend/phpstan-baseline.neon','apps/backend/composer.lock') }}
+      - name: Run PHPStan
+        working-directory: apps/backend
+        run: php vendor/bin/phpstan analyse -c phpstan.neon.dist --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,17 @@ jobs:
   pint:
     name: Laravel Pint code style
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/backend
     steps:
       - uses: actions/checkout@v4
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.3"
+          php-version: '8.3'
           tools: composer
 
-      - run: composer install --no-interaction --prefer-dist
+      - name: Composer install (backend app)
+        working-directory: apps/backend
+        run: composer install --no-interaction --prefer-dist
 
       - name: Pint (app + package)
         run: vendor/bin/pint --test . ../../packages/plenipotentiary-laravel
@@ -27,24 +26,24 @@ jobs:
   pest:
     name: Pest tests
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/backend
     steps:
       - uses: actions/checkout@v4
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.3"
+          php-version: '8.3'
           tools: composer
 
-      - run: composer install --no-interaction --prefer-dist
+      - name: Composer install (backend app)
+        working-directory: apps/backend
+        run: composer install --no-interaction --prefer-dist
 
       - name: Pest (backend app)
+        working-directory: apps/backend
         run: vendor/bin/pest --colors=always --testsuite=Feature
 
       - name: Pest (package plenipotentiary-laravel)
-        working-directory: ../../packages/plenipotentiary-laravel
+        working-directory: packages/plenipotentiary-laravel
         run: |
           composer install --no-interaction --prefer-dist
           vendor/bin/pest --colors=always

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ apps/backend/vendor-bin/**/vendor/
 apps/backend/coverage/
 apps/backend/coverage.xml
 
+**/.phpunit.cache/
+**/.phpstan/
+
 # =============================================================================
 # Frontend: Vite/TS + pnpm (apps/frontend)
 # =============================================================================
@@ -123,6 +126,10 @@ packages/plenipotentiary-laravel/vendor
 # =============================================================================
 # Repo-level tools
 # =============================================================================
+
+# Static analysis & test caches
+**/.phpstan/
+**/.phpunit.cache/
 
 # Prettier, ESLint, etc. caches (if created at root)
 .eslintcache

--- a/Justfile
+++ b/Justfile
@@ -102,6 +102,13 @@ sh:
       {{compose}} exec -it -u {{container_user}} {{api_svc}} bash; \
     fi
 
+sh-root:
+    @if [ "{{_in_container}}" = "1" ]; then \
+      exec -u root bash; \
+    else \
+      {{compose}} exec -it -u root {{api_svc}} bash; \
+    fi
+
 up:
     @{{ensure_host}}
     {{compose}} up -d {{db_svc}} {{cache_svc}} {{mail_svc}} {{api_svc}} {{web_svc}}
@@ -141,6 +148,29 @@ test:
 
 test-cov:
     @just run-backend '(composer run -q test:cov || php artisan test --coverage --min=0)'
+
+watch-app-tests:
+    @{{ensure_host}}
+    watchexec -e php -w apps/backend -- \
+      docker compose exec api vendor/bin/pest --colors=always
+
+watch-package-tests:
+    @{{ensure_host}}
+    watchexec -e php -w packages/plenipotentiary-laravel -- \
+      docker compose exec api bash -lc "cd /workspaces/stack-root/packages/plenipotentiary-laravel && vendor/bin/pest --colors=always"
+
+# Watch BOTH in parallel with prefixed output
+watch-all-tests:
+	@{{ensure_host}}
+	bash -ceu '\
+	  prefix(){ stdbuf -oL sed -e "s/^/[$$1] /"; } ; \
+	  ( watchexec -e php -w apps/backend -- \
+	      docker compose exec api vendor/bin/pest --colors=always | prefix app ) & APP=$$! ; \
+	  ( watchexec -e php -w packages/plenipotentiary-laravel -- \
+	      docker compose exec api bash -lc "cd /workspaces/stack-root/packages/plenipotentiary-laravel && vendor/bin/pest --colors=always" | prefix pkg ) & PKG=$$! ; \
+	  trap "kill $$APP $$PKG" INT TERM ; \
+	  wait \
+	'
 
 lint:
     @just run-backend 'composer lint'

--- a/Justfile
+++ b/Justfile
@@ -152,31 +152,52 @@ test-cov:
 watch-app-tests:
     @{{ensure_host}}
     watchexec -e php -w apps/backend -- \
-      docker compose exec api vendor/bin/pest --colors=always
+      {{compose}} exec -T {{api_svc}} vendor/bin/pest --colors=always
 
 watch-package-tests:
     @{{ensure_host}}
     watchexec -e php -w packages/plenipotentiary-laravel -- \
-      docker compose exec api bash -lc "cd /workspaces/stack-root/packages/plenipotentiary-laravel && vendor/bin/pest --colors=always"
+      {{compose}} exec -T {{api_svc}} bash -lc "cd /workspaces/stack-root/packages/plenipotentiary-laravel && vendor/bin/pest --colors=always"
 
 # Watch BOTH in parallel with prefixed output
 watch-all-tests:
-	@{{ensure_host}}
-	bash -ceu '\
-	  prefix(){ stdbuf -oL sed -e "s/^/[$$1] /"; } ; \
-	  ( watchexec -e php -w apps/backend -- \
-	      docker compose exec api vendor/bin/pest --colors=always | prefix app ) & APP=$$! ; \
-	  ( watchexec -e php -w packages/plenipotentiary-laravel -- \
-	      docker compose exec api bash -lc "cd /workspaces/stack-root/packages/plenipotentiary-laravel && vendor/bin/pest --colors=always" | prefix pkg ) & PKG=$$! ; \
-	  trap "kill $$APP $$PKG" INT TERM ; \
-	  wait \
-	'
+    @{{ensure_host}}
+    bash -ceu '\
+      prefix(){ stdbuf -oL sed -e "s/^/[$$1] /"; } ; \
+      ( watchexec -e php -w apps/backend -- \
+          {{compose}} exec -T {{api_svc}} vendor/bin/pest --colors=always | prefix app ) & APP=$$! ; \
+      ( watchexec -e php -w packages/plenipotentiary-laravel -- \
+          {{compose}} exec -T {{api_svc}} bash -lc "cd /workspaces/stack-root/packages/plenipotentiary-laravel && vendor/bin/pest --colors=always" | prefix pkg ) & PKG=$$! ; \
+      trap "kill $$APP $$PKG" INT TERM ; \
+      wait \
+    '
 
-lint:
-    @just run-backend 'composer lint'
+# Pint (check) — run from anywhere. Optional args to restrict paths.
+pint *paths:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+      set -eu; export XDEBUG_MODE=off; \
+      cd /workspaces/stack-root/apps/backend; \
+      [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+      if [ -z "{{paths}}" ]; then set -- . ../../packages/plenipotentiary-laravel; else set -- {{paths}}; fi; \
+      echo "[pint --test] $@"; vendor/bin/pint --test "$@" \
+    '
 
-lint-fix:
-    @just run-backend 'composer lint:fix'
+# Pint (fix)
+pint-fix *paths:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+      set -eu; export XDEBUG_MODE=off; \
+      cd /workspaces/stack-root/apps/backend; \
+      [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+      if [ -z "{{paths}}" ]; then set -- . ../../packages/plenipotentiary-laravel; else set -- {{paths}}; fi; \
+      echo "[pint --fix] $@"; vendor/bin/pint "$@" \
+    '
+
+# Friendly aliases so old muscle-memory still works
+lint *paths:
+    just pint {{paths}}
+
+lint-fix *paths:
+    just pint-fix {{paths}}
 
 stan:
     @just run-backend 'composer stan'
@@ -260,12 +281,14 @@ fe-store-clear:
 
 ci:
     just ci-pint
+    just ci-phpstan
     just ci-backend-sqlite
     just ci-package
     just ci-frontend
 
 ci-all:
     just ci-pint
+    just ci-phpstan
     just ci-backend-sqlite
     just ci-backend-mysql
     just ci-package
@@ -279,6 +302,70 @@ ci-pint:
     vendor/bin/pint --test . ../../packages/plenipotentiary-laravel \
     '
 
+ci-phpstan:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+    set -eu; \
+    export XDEBUG_MODE=off; \
+    cd /workspaces/stack-root/apps/backend; \
+    [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+    mkdir -p /tmp/phpstan-app; \
+    php -d memory_limit=2G vendor/bin/phpstan analyse -c phpstan.neon.dist --no-progress \
+    '
+ci-phpstan-split:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+    set -eu; \
+    export XDEBUG_MODE=off; \
+    cd /workspaces/stack-root/apps/backend; \
+    [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+    mkdir -p /tmp/phpstan-app; \
+    php -d memory_limit=1G vendor/bin/phpstan analyse app database -c phpstan.neon.dist --no-progress; \
+    php -d memory_limit=1G vendor/bin/phpstan analyse ../../packages/plenipotentiary-laravel/src -c phpstan.neon.dist --no-progress \
+    '
+
+# Strict mode to catch new issues (baseline still applied if included in config)
+ci-phpstan-max:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+    set -eu; \
+    export XDEBUG_MODE=off; \
+    cd /workspaces/stack-root/apps/backend; \
+    [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+    mkdir -p /tmp/phpstan-app; \
+    php -d memory_limit=2G vendor/bin/phpstan analyse -c phpstan.neon.dist --level=max --no-progress \
+    '
+
+# Regenerate the baseline at max (use when you’ve fixed stuff)
+ci-phpstan-baseline:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+    set -eu; \
+    export XDEBUG_MODE=off; \
+    cd /workspaces/stack-root/apps/backend; \
+    [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+    mkdir -p /tmp/phpstan-app; \
+    php -d memory_limit=2G vendor/bin/phpstan analyse -c phpstan.neon.dist --level=max --generate-baseline=phpstan-baseline.neon --no-progress \
+    '
+
+# Package-only scan (lower peak RAM than scanning everything)
+ci-phpstan-package:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+    set -eu; \
+    export XDEBUG_MODE=off; \
+    cd /workspaces/stack-root/apps/backend; \
+    [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+    mkdir -p /tmp/phpstan-app; \
+    php -d memory_limit=2G vendor/bin/phpstan analyse -c phpstan.neon.dist ../../packages/plenipotentiary-laravel/src --no-progress \
+    '
+
+# Debug (single worker-ish output to find crashes)
+ci-phpstan-debug:
+    @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+    set -eu; \
+    export XDEBUG_MODE=off; \
+    cd /workspaces/stack-root/apps/backend; \
+    [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
+    mkdir -p /tmp/phpstan-app; \
+    php -d memory_limit=2G vendor/bin/phpstan analyse -c phpstan.neon.dist --debug --no-progress \
+    '
+    
 # Backend tests with sqlite (default, in-memory DB + array cache)
 ci-backend-sqlite:
     @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
@@ -310,9 +397,14 @@ ci-backend-mysql:
 # Package tests (plenipotentiary-laravel)
 ci-package:
     @{{compose}} exec -T -u {{container_user}} {{api_svc}} bash -lc '\
+    set -eu; \
     cd /workspaces/stack-root/packages/plenipotentiary-laravel; \
     [ -f vendor/autoload.php ] || composer install --no-interaction --no-progress --prefer-dist; \
-    vendor/bin/pest --colors=always \
+    export EXAMPLES_ROOT=/workspaces/stack-root/docs/openapi/examples; \
+    vendor/bin/pest --colors=always --testsuite=Contracts; \
+    vendor/bin/pest --colors=always --testsuite=Package; \
+    vendor/bin/pest --colors=always --testsuite=Feature; \
+    vendor/bin/pest --colors=always --testsuite=Unit \
     '
 
 # Frontend (lint, typecheck, test, build)

--- a/apps/backend/composer.json
+++ b/apps/backend/composer.json
@@ -68,7 +68,10 @@
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
-        ]
+        ],
+        "stan": "php -d memory_limit=1G vendor/bin/phpstan analyse -c phpstan.neon.dist --no-progress",
+        "stan:max": "php -d memory_limit=1G vendor/bin/phpstan analyse -c phpstan.neon.dist --level=max --no-progress",
+        "stan:baseline": "php -d memory_limit=1G vendor/bin/phpstan analyse -c phpstan.neon.dist --level=max --generate-baseline=phpstan-baseline.neon --no-progress"
     },
     "extra": {
         "laravel": {

--- a/apps/backend/phpstan-baseline.neon
+++ b/apps/backend/phpstan-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Method App\\Http\\Middleware\\TrustHosts\:\:hosts\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/TrustHosts.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\UserFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\User, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\User\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/UserFactory.php

--- a/apps/backend/phpstan.neon.dist
+++ b/apps/backend/phpstan.neon.dist
@@ -1,9 +1,21 @@
 includes:
   - vendor/larastan/larastan/extension.neon
+  # Optional: better datetime types
+  # - vendor/nesbot/carbon/extension.neon
+  - phpstan-baseline.neon
 
 parameters:
+  bootstrapFiles:
+    - vendor/autoload.php
+
   paths:
     - app
     - database
+    - ../../packages/plenipotentiary-laravel/src   # <- correct relative path
+
   level: 6
-  tmpDir: storage/framework/cache/phpstan
+  tmpDir: /tmp/phpstan-app                         # local, cacheable
+  parallel:
+    maximumNumberOfProcesses: 2
+  checkModelProperties: true
+  inferPrivatePropertyTypeFromConstructor: true

--- a/packages/plenipotentiary-laravel/.phpunit.cache/test-results
+++ b/packages/plenipotentiary-laravel/.phpunit.cache/test-results
@@ -1,1 +1,0 @@
-{"version":"pest_3.8.4","defects":[],"times":{"P\\Tests\\Package\\BindsContractsTest::__pest_evaluable_it_binds_AuthStrategy_to_a_concrete_implementation":0.108,"P\\Tests\\Package\\ExampleTest::__pest_evaluable_it_boots_the_provider":0.002,"P\\Tests\\Package\\LoadsConfigTest::__pest_evaluable_it_merges_package_config":0.002}}

--- a/packages/plenipotentiary-laravel/phpunit.xml
+++ b/packages/plenipotentiary-laravel/phpunit.xml
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Package">
-      <directory>tests/Package</directory>
+      <directory suffix="Test.php">tests/Package</directory>
+    </testsuite>
+    <testsuite name="Contracts">
+      <directory suffix="Test.php">tests/Contracts</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">tests/Feature</directory>
+    </testsuite>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">tests/Unit</directory>
+    </testsuite>
+    <!-- convenient catch-all -->
+    <testsuite name="All">
+      <directory suffix="Test.php">tests</directory>
     </testsuite>
   </testsuites>
+
   <source restrictNotices="true" restrictWarnings="true" ignoreIndirectDeprecations="true">
     <include>
       <directory suffix=".php">src</directory>

--- a/packages/plenipotentiary-laravel/src/PleniServiceProvider.php
+++ b/packages/plenipotentiary-laravel/src/PleniServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Plenipotentiary\Laravel;
 
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Plenipotentiary\Laravel\Auth\NoopAuth;
 use Plenipotentiary\Laravel\Contracts\AuthStrategy;
@@ -14,12 +15,13 @@ class PleniServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/pleni.php', 'pleni');
 
         // Minimal, testable seam: bind the default AuthStrategy
-        $this->app->bind(AuthStrategy::class, function ($app) {
-            $default = (string) config('pleni.auth.default', 'noop');
+        $this->app->bind(AuthStrategy::class, function (Container $app): AuthStrategy {
+            $raw = config('pleni.auth.default');
+            $default = is_string($raw) && $raw !== '' ? $raw : 'noop';
 
             return match ($default) {
-                'noop' => new NoopAuth,
-                default => new NoopAuth, // placeholder until real strategies land
+                'noop' => $app->make(NoopAuth::class),
+                default => $app->make(NoopAuth::class),
             };
         });
     }

--- a/packages/plenipotentiary-laravel/tests/Contracts/ApiContractTestCase.php
+++ b/packages/plenipotentiary-laravel/tests/Contracts/ApiContractTestCase.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Plenipotentiary\Laravel\Tests\Contracts;
+
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class ApiContractTestCase extends BaseTestCase
+{
+    protected string $examplesRoot = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $candidates = [
+            getenv('EXAMPLES_ROOT') ?: null,
+            realpath(\dirname(__DIR__, 4).'/docs/openapi/examples') ?: null, // repo root/docs/...
+            realpath(getcwd().'/../../docs/openapi/examples') ?: null,       // when CWD = package/
+        ];
+
+        foreach ($candidates as $dir) {
+            if ($dir && is_dir($dir)) {
+                $this->examplesRoot = $dir;
+                break;
+            }
+        }
+
+        if ($this->examplesRoot === '') {
+            $this->fail('EXAMPLES_ROOT not found. Set env EXAMPLES_ROOT or add docs/openapi/examples to repo.');
+        }
+
+        Http::preventStrayRequests();
+    }
+
+    protected function example(string $relative): array
+    {
+        $path = rtrim($this->examplesRoot, '/').'/'.ltrim($relative, '/');
+        if (! is_file($path)) {
+            $this->fail("Missing example fixture: {$path}");
+        }
+        $json = file_get_contents($path);
+
+        return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    protected function fakeJson(string $urlPattern, string $exampleFile, int $status = 200, array $headers = []): void
+    {
+        $payload = $this->example($exampleFile);
+        Http::fake([
+            $urlPattern => Http::response(
+                $payload,
+                $status,
+                array_merge(['Content-Type' => 'application/json'], $headers)
+            ),
+        ]);
+    }
+
+    protected function assertPagination(array $json, int $perPage, ?int $total = null): void
+    {
+        $this->assertArrayHasKey('data', $json);
+        $this->assertArrayHasKey('meta', $json);
+        $this->assertSame($perPage, $json['meta']['per_page'] ?? null);
+        if ($total !== null) {
+            $this->assertSame($total, $json['meta']['total'] ?? null);
+        }
+    }
+
+    protected function assertApiError(array $json, string $code, int $status): void
+    {
+        $this->assertArrayHasKey('error', $json);
+        $this->assertSame($code, $json['error']['code'] ?? null);
+        $this->assertSame($status, $json['error']['status'] ?? null);
+    }
+}

--- a/packages/plenipotentiary-laravel/tests/Contracts/CustomersContractTest.php
+++ b/packages/plenipotentiary-laravel/tests/Contracts/CustomersContractTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Plenipotentiary\Laravel\Tests\Contracts;
+
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('contracts')]
+final class CustomersContractTest extends ApiContractTestCase
+{
+    public function it_conforms_to_index_contract(): void
+    {
+        $this->fakeJson('*/customers*', 'customers/index.json');
+
+        $res = Http::get('https://plenipotentiary-sandbox.test/acmecart/backoffice/customers?page=1');
+        $this->assertTrue($res->ok(), 'Response not OK');
+
+        $json = $res->json();
+        $this->assertPagination($json, perPage: 2, total: 2);
+        $this->assertCount(2, $json['data']);
+        $this->assertSame('C-1001', $json['data'][0]['id']);
+    }
+}

--- a/packages/plenipotentiary-laravel/tests/Feature/ExampleTest.php
+++ b/packages/plenipotentiary-laravel/tests/Feature/ExampleTest.php
@@ -3,5 +3,5 @@
 it('returns a successful response', function () {
     $response = $this->get('/');
 
-    $response->assertStatus(200);
+    $response->assertNoContent();
 });

--- a/packages/plenipotentiary-laravel/tests/Pest.php
+++ b/packages/plenipotentiary-laravel/tests/Pest.php
@@ -3,4 +3,4 @@
 use Plenipotentiary\Laravel\Tests\Support\TestCase;
 
 // Make all tests in tests/Package use Laravel Testbench base
-uses(TestCase::class)->in('Package');
+uses(TestCase::class)->in('Feature', 'Package', 'Contracts', 'Unit');

--- a/packages/plenipotentiary-laravel/tests/Support/TestCase.php
+++ b/packages/plenipotentiary-laravel/tests/Support/TestCase.php
@@ -2,20 +2,28 @@
 
 namespace Plenipotentiary\Laravel\Tests\Support;
 
+use Illuminate\Routing\Router;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Plenipotentiary\Laravel\PleniServiceProvider;
 
 abstract class TestCase extends Orchestra
 {
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [PleniServiceProvider::class];
     }
 
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
-        // Override any defaults for predictable tests if needed
+        // Config only
         $app['config']->set('pleni.observability.enabled', false);
         $app['config']->set('pleni.auth.default', 'noop');
+    }
+
+    /** Register test-only routes here */
+    protected function defineRoutes($router): void
+    {
+        /** @var Router $router */
+        $router->get('/', fn () => response()->noContent());
     }
 }


### PR DESCRIPTION
# Epic E0: Testing & Tooling — merge to `main`

**Goal:** Establish test/tooling foundations before package & adapter work.

## ✅ Deliverables
- [x] Pest configured and running (app + package)
- [x] Static analysis set up (Larastan/PHPStan) with baseline
- [x] Code style checks wired (Laravel Pint)
- [x] CI pipeline green (tests + analysis + style)
- [x] Contract test base in `packages/plenipotentiary-laravel/tests/Contracts`
- [x] Example fixtures in `docs/openapi/examples`

## Notes
- CI jobs: `pint`, `pest`, `phpstan`
- Package contract tests run with Testbench and EXAMPLES_ROOT
- `.editorconfig` added to normalize EOF/newlines

After merge: tag `v0.1.0` (“E0 foundation”), require checks on `main`.
